### PR TITLE
Platform compatibility issue in minimap2comm.sh

### DIFF
--- a/inst/bash/minimap2comm.sh
+++ b/inst/bash/minimap2comm.sh
@@ -9,21 +9,25 @@ genomeFa=$4;
 numThreads=$5;
 
 ## Create a fastq guide
-for i in $(ls $fastqDir/*.fastq.gz) ; do echo $i | awk -v path=$(pwd) \
-'{n=split($1,a,/\/|.fastq/); print a[n-1]"\t"path"/"$1}' ; done > Misc/fastqGuide
+for i in $(ls $fastqDir/*.fastq.gz); do 
+    echo $i | awk -v path=$(pwd) \
+    '{n=split($1,a,/\/|.fastq/); print a[n-1]"\t"path"/"$1}'
+done > Misc/fastqGuide
 
 ## Running minimap2 over all files listed in the guide
-n=`cat Misc/fastqGuide | wc -l` ; for i in `seq 1 $n` ; do name=`cat Misc/fastqGuide \
-| head -$i | tail -1 | awk '{print $1;}'` ; \
-echo "### treating "$name >> $mmOut/REPORT.minimap2 ; \
-file=`cat Misc/fastqGuide | head -$i | tail -1 | awk '{print $2}'` ; \
-$progPath -t $numThreads -ax splice --secondary=no $genomeFa \
-$file > $mmOut/$name.sam ; done &>> $mmOut/REPORT.minimap2
+n=`cat Misc/fastqGuide | wc -l`
+for i in `seq 1 $n`; do
+    name=`cat Misc/fastqGuide | head -$i | tail -1 | awk '{print $1;}'`
+    echo "### treating $name" >> $mmOut/REPORT.minimap2
+    file=`cat Misc/fastqGuide | head -$i | tail -1 | awk '{print $2}'`
+    $progPath -t $numThreads -ax splice --secondary=no $genomeFa \
+        $file > $mmOut/$name.sam
+done >> $mmOut/REPORT.minimap2
 
-for i in $(ls $mmOut/*.sam) ; \
-do name=`echo $i | awk '{n=split($1,a,/\/|.sam/); print a[n-1]}'`; \
-samtools view -bh $i -o $mmOut/$name.bam ; \
-rm $mmOut/$name.sam; \
+for i in $(ls $mmOut/*.sam); do 
+    name=`echo $i | awk '{n=split($1,a,/\/|.sam/); print a[n-1]}'`
+    samtools view -bh $i -o $mmOut/$name.bam
+    rm $mmOut/$name.sam
 done
 
 


### PR DESCRIPTION
I tested the command on macOS and Debian, both ran into errors:

macOS:
```
/Library/Frameworks/R.framework/Versions/4.1/Resources/library/scisorseqr/bash/minimap2comm.sh: line 21: syntax error near unexpected token `>'
/Library/Frameworks/R.framework/Versions/4.1/Resources/library/scisorseqr/bash/minimap2comm.sh: line 21: `$file > $mmOut/$name.sam ; done &>> $mmOut/REPORT.minimap2'
```

Debian:
```
bedtools found in path
samtools found in path
[1] "Aligning with minimap2"
ls: cannot access 'MMoutput//*.sam': No such file or directory
ls: cannot access 'MMoutput//*.bam': No such file or directory
root@603cf89ef177:/# ll us[M::mm_idx_gen::15.558*0.90] collected minimizers
[M::mm_idx_gen::34.303*0.70] sorted minimizers
[M::main::34.314*0.70] loaded/built the index for 2 target sequence(s)
[M::mm_mapopt_update::35.122*0.71] mid_occ = 204
[M::mm_idx_stat] kmer size: 15; skip: 5; is_hpc: 0; #seq: 2
[M::mm_idx_stat::35.455*0.71] distinct minimizers: 25421542 (80.73% are singletons); average occurrences: 1.604; average spacing: 3.217; total length: 131191753
[M::worker_pipeline::297.882*0.98] mapped 12775 sequences
[M::main] Version: 2.22-r1101
[M::main] CMD: /tools/minimap2 -t 1 -ax splice --secondary=no data/GRCh38.primary_assembly.chr18.chr22.fa.gz //data//ROCR3_B-F1_chr18.fastq.gz
[M::main] Real time: 298.765 sec; CPU: 291.377 sec; Peak RSS: 1.415 GB
```

NOTICE the two `ls` lines above -- that means the next for loop was executed before minimap2 was done.

I then deleted the `&` in line `$file > $mmOut/$name.sam ; done &>> $mmOut/REPORT.minimap2`, it solves the issues on both platforms, I also reformatted the code a little..

```
root@603cf89ef177:/# Rscript align.R 1 data/ $(which minimap2) data/GRCh38.primary_assembly.chr18.chr22.fa.gz 
bedtools found in path
samtools found in path
[1] "Aligning with minimap2"
[M::mm_idx_gen::7.716*1.05] collected minimizers
[M::mm_idx_gen::34.333*0.88] sorted minimizers
[M::main::34.353*0.88] loaded/built the index for 2 target sequence(s)
[M::mm_mapopt_update::39.270*0.90] mid_occ = 204
[M::mm_idx_stat] kmer size: 15; skip: 5; is_hpc: 0; #seq: 2
[M::mm_idx_stat::39.894*0.90] distinct minimizers: 25421542 (80.73% are singletons); average occurrences: 1.604; average spacing: 3.217; total length: 131191753
[M::worker_pipeline::344.468*1.00] mapped 12775 sequences
[M::main] Version: 2.22-r1101
[M::main] CMD: /tools/minimap2 -t 1 -ax splice --secondary=no data/GRCh38.primary_assembly.chr18.chr22.fa.gz //data//ROCR3_B-F1_chr18.fastq.gz
[M::main] Real time: 344.998 sec; CPU: 344.022 sec; Peak RSS: 1.552 GB
root@603cf89ef177:
```

Those `ls` errors were gone! executed in the correct order and got the bam file